### PR TITLE
add: Quick-start and example configuration+dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,71 @@ Some features, current and future:
   prevent that a flood of incoming connections spawns of a flood of containers
   that overwhelm the Docker host.
 
-## Usage
+## Quickstart
+Attention: This is just a quick-start and not suitable for production.
 
-TODO
+Prerequisites:
+- A docker image of your choice is needed
+  - The image requires a running ssh-server and a known user/password (See `\example\Dockerfile` for a simple example)
+- root or root-privileges are needed for setup
+
+````bash
+# start in your home directory
+cd ~
+# clone this repository
+git clone https://github.com/OverTheWireOrg/docker-tcp-switchboard.git
+# install and start docker. You'll be able to control docker without root
+sudo apt-get -y install docker-ce
+sudo service docker start
+sudo usermod -a -G docker **yourusername**
+# install requirements
+cd /docker-tcp-switchboard
+sudo apt install python3-pip
+pip3 install -r requirements.txt
+# setup logfile
+touch /var/log/docker-tcp-switchboard.log
+chmod a+w /var/log/docker-tcp-switchboard.log
+# create the configuration file
+vi /etc/docker-tcp-switchboard.conf #paste your configuration file here (see below)
+# start docker-tcp-switchboard. It'll run in the foreground.
+python3 docker-tcp-switchboard.py
+````
+Done! Now connect to your `outerport` to start a fresh container.
+
 
 ## Example configuration file
+````ini
+[global]
+logfile = /var/log/docker-tcp-switchboard.log
+loglevel = DEBUG
 
-TODO
+[profile:firstcontainer]
+innerport = 22
+outerport = 32768
+container = imagename
+limit = 10
+reuse = false
+
+[profile:differentcontainer]
+innerport = 22
+outerport = 32769
+container = differentimagename
+limit = 5
+reuse = false
+
+[dockeroptions:differentcontainer]
+ports={"8808/tcp":null}
+volumes={"/home/ubuntu/mountthisfolder/": {"bind": "/mnd/folderincointainer/", "mode": "rw"}}
+
+````
+
+### misc
+- See logfile for debugging (`tail -f /var/log/docker-tcp-switchboard.log`)
+- To auto-disconnect when idle, use SSHD config options "ClientAliveInterval" and "ServerAliveCountMax"
+- Remember to unblock "outerport" in your firewall
+- See [Docker SDK for Python](https://docker-py.readthedocs.io/en/stable/containers.html) for troubleshooting and available dockeroptions
+
+
 
 
 [OverTheWire]: http://overthewire.org

--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -1,0 +1,41 @@
+FROM ubuntu:16.04
+
+#--------- Install usefull tools -----------
+RUN apt-get update && apt-get install -y \
+  openssh-server \
+  git \
+  curl \
+  vim \
+  apt-utils \
+  iputils-ping \
+  sudo
+
+#--------- SETUP System -----------
+
+# add user and sudo
+RUN useradd -ms /bin/bash -g sudo sshuser
+# username= sshuser, password= password
+RUN echo 'sshuser:password' | chpasswd
+RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+# Config SSH
+# Set SSH timeout
+RUN mkdir /var/run/sshd
+#set timeout to auto-disconnect when idle (see man sshd)
+#RUN echo 'ClientAliveInterval 60' >>  /etc/ssh/sshd_config
+#RUN echo 'ClientAliveCountMax 10' >>  /etc/ssh/sshd_config
+#RUN echo 'TCPKeepAlive no' >>  /etc/ssh/sshd_config
+
+#--------- SETUP USER -----------
+
+USER sshuser
+WORKDIR /home/sshuser/
+
+#------------- ROOT -------------
+
+USER root
+
+# Setup SSH
+EXPOSE 22
+# Start SSH Deamon in "not detach" mode. Once SSH connction breaks the container stops
+CMD ["/usr/sbin/sshd", "-D"]

--- a/example/docker-tcp-switchboard.conf
+++ b/example/docker-tcp-switchboard.conf
@@ -1,4 +1,11 @@
 [global]
 splitconfigfiles = /etc/docker-tcp-switchboard.d/*.conf
 logfile = /var/log/docker-tcp-switchboard.log
-loglevel = INFO
+loglevel = DEBUG
+
+[testssh]
+innerport = 22
+outerport = 32768
+container = testcontainer
+limit = 5
+reuse = false


### PR DESCRIPTION
Thanks for making your code public!
I added a quick-start, a example configuration and a simple Dockerfile to provide some information about usage.
It took me quite some time to figure out how to use your application. It would be a shame to prevent others of using it just because of missing examples.

My example does not include advanced configurations. Just stuff I figured out by trail&error+looking at your code/using it.

This also addresses: https://github.com/OverTheWireOrg/docker-tcp-switchboard/issues/11
